### PR TITLE
Added and configured prettier, including php plugin

### DIFF
--- a/.prettierc
+++ b/.prettierc
@@ -1,0 +1,11 @@
+{
+    "pluginSearchDirs": [
+        "."
+    ],
+    "plugins": [
+        "@prettier/plugin-php"
+    ],
+    "printWidth": 100,
+    "singleQuote": true,
+    "endOfLine": "auto"
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.DS_Store
+/node_modules
+/config
+
+package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-    "name": "website-sinf-2023",
+    "name": "website-2023",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "devDependencies": {
                 "@inertiajs/vue3": "^1.0.0",
+                "@prettier/plugin-php": "^0.19.5",
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/typography": "^0.5.2",
                 "@vitejs/plugin-vue": "^4.0.0",
@@ -13,6 +14,7 @@
                 "axios": "^1.1.2",
                 "laravel-vite-plugin": "^0.7.5",
                 "postcss": "^8.4.14",
+                "prettier": "^2.8.8",
                 "tailwindcss": "^3.1.0",
                 "vite": "^4.0.0",
                 "vue": "^3.2.31"
@@ -507,6 +509,20 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@prettier/plugin-php": {
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.19.5.tgz",
+            "integrity": "sha512-AnmiB76G7qX2d7FbvGgABc3l4dVshOlBqxajiHe8nfMVTzmge7xDhiC28aP8OZafhIRksLKNRB1ZEemfN+j5pg==",
+            "dev": true,
+            "dependencies": {
+                "linguist-languages": "^7.21.0",
+                "mem": "^8.0.0",
+                "php-parser": "^3.1.3"
+            },
+            "peerDependencies": {
+                "prettier": "^1.15.0 || ^2.0.0"
             }
         },
         "node_modules/@tailwindcss/forms": {
@@ -1330,6 +1346,12 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "node_modules/linguist-languages": {
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.21.0.tgz",
+            "integrity": "sha512-KrWJJbFOvlDhjlt5OhUipVlXg+plUfRurICAyij1ZVxQcqPt/zeReb9KiUVdGUwwhS/2KS9h3TbyfYLA5MDlxQ==",
+            "dev": true
+        },
         "node_modules/lodash.castarray": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
@@ -1370,6 +1392,34 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "dependencies": {
+                "p-defer": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/mem": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+            "dev": true,
+            "dependencies": {
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/mem?sponsor=1"
             }
         },
         "node_modules/merge2": {
@@ -1413,6 +1463,15 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/mini-svg-data-uri": {
@@ -1531,6 +1590,15 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1544,6 +1612,12 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "node_modules/php-parser": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.4.tgz",
+            "integrity": "sha512-WUEfH4FWsVItqgOknM67msDdcUAfgPJsHhPNl6EPXzWtX+PfdY282m4i8YIJ9ALUEhf+qGDajdmW+VYqSd7Deg==",
             "dev": true
         },
         "node_modules/picocolors": {
@@ -1725,6 +1799,21 @@
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
+        },
+        "node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
@@ -2390,6 +2479,17 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@prettier/plugin-php": {
+            "version": "0.19.5",
+            "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.19.5.tgz",
+            "integrity": "sha512-AnmiB76G7qX2d7FbvGgABc3l4dVshOlBqxajiHe8nfMVTzmge7xDhiC28aP8OZafhIRksLKNRB1ZEemfN+j5pg==",
+            "dev": true,
+            "requires": {
+                "linguist-languages": "^7.21.0",
+                "mem": "^8.0.0",
+                "php-parser": "^3.1.3"
+            }
+        },
         "@tailwindcss/forms": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
@@ -3000,6 +3100,12 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "linguist-languages": {
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.21.0.tgz",
+            "integrity": "sha512-KrWJJbFOvlDhjlt5OhUipVlXg+plUfRurICAyij1ZVxQcqPt/zeReb9KiUVdGUwwhS/2KS9h3TbyfYLA5MDlxQ==",
+            "dev": true
+        },
         "lodash.castarray": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
@@ -3039,6 +3145,25 @@
                 "@jridgewell/sourcemap-codec": "^1.4.13"
             }
         },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
+        "mem": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.1.0"
+            }
+        },
         "merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3069,6 +3194,12 @@
             "requires": {
                 "mime-db": "1.52.0"
             }
+        },
+        "mimic-fn": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+            "dev": true
         },
         "mini-svg-data-uri": {
             "version": "1.4.4",
@@ -3153,6 +3284,12 @@
                 "wrappy": "1"
             }
         },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+            "dev": true
+        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3163,6 +3300,12 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "php-parser": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.1.4.tgz",
+            "integrity": "sha512-WUEfH4FWsVItqgOknM67msDdcUAfgPJsHhPNl6EPXzWtX+PfdY282m4i8YIJ9ALUEhf+qGDajdmW+VYqSd7Deg==",
             "dev": true
         },
         "picocolors": {
@@ -3265,6 +3408,12 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true
         },
         "proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "prettier": "prettier --single-quote --trailing-comma-php --print-width 100 --write"
     },
     "devDependencies": {
         "@inertiajs/vue3": "^1.0.0",
+        "@prettier/plugin-php": "^0.19.5",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/typography": "^0.5.2",
         "@vitejs/plugin-vue": "^4.0.0",
@@ -14,6 +16,7 @@
         "axios": "^1.1.2",
         "laravel-vite-plugin": "^0.7.5",
         "postcss": "^8.4.14",
+        "prettier": "^2.8.8",
         "tailwindcss": "^3.1.0",
         "vite": "^4.0.0",
         "vue": "^3.2.31"


### PR DESCRIPTION
This pull request aims to introduce consistent code formatting across the project.
Installed and configured prettier with the php plugin, along with an npm script which can run the formatter in the whole project (`npm run prettier <directory/file>` in the terminal). 
The prettier configuration file already contains options that I consider relevant, but it isn't meant to be definitive, just like the `.prettierignore` file. If you have any suggestions, namely regarding more code formatting options or even a different code formatter altogether, please leave a comment below.