### PR TITLE
Placeholder text on empty event/quest containers

### DIFF
--- a/resources/js/Components/Profile/StickerWrapper.vue
+++ b/resources/js/Components/Profile/StickerWrapper.vue
@@ -4,7 +4,14 @@ import Sticker from "./Sticker.vue";
 </script>
 
 <template>
+    <p
+        v-if="($page.props.slots as Slot[]).length === 0"
+        class="flex w-full flex-auto items-center justify-center pt-8 text-center text-2xl font-bold text-2023-teal-dark"
+    >
+        Ainda não há conquistas para completares. Fica de olho nesta secção!
+    </p>
     <div
+        v-else
         class="flex w-full flex-row flex-wrap items-center justify-center gap-8 place-self-center self-center pt-8"
     >
         <svg width="0" height="0" class="fixed">

--- a/resources/js/Components/Profile/TicketWrapper.vue
+++ b/resources/js/Components/Profile/TicketWrapper.vue
@@ -31,8 +31,14 @@ const getTicketState = (t: EventTicket): "used" | "acquired" | "available" => {
             />
         </clipPath>
     </svg>
-
+    <p
+        v-if="($page.props.tickets as EventTicket[]).length === 0"
+        class="flex w-full flex-auto items-center justify-center pt-8 text-center text-2xl font-bold text-2023-teal-dark"
+    >
+        Ainda não há eventos marcados. Verifica mais tarde!
+    </p>
     <div
+        v-else
         class="grid w-full items-center justify-center gap-10 self-center pt-8"
         style="grid-template-columns: repeat(auto-fill, 350px)"
     >


### PR DESCRIPTION
Closes #202
When there are no events and/or quests in the database, placeholder text now appears on the profile page.

![image](https://github.com/semanadeinformatica/website-2023/assets/75742355/85e8e6e9-f543-4e51-bde4-3d01a5a8b231)
![image](https://github.com/semanadeinformatica/website-2023/assets/75742355/032ea760-1403-488d-a980-1c4eb9e56a51)
