### PR TITLE
Automatic selection of current program day

### DIFF
--- a/app/Http/Controllers/ProgramController.php
+++ b/app/Http/Controllers/ProgramController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Edition;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Validator;
 use Inertia\Inertia;
 
@@ -43,7 +45,7 @@ class ProgramController extends Controller
         }
 
         $validated = $validator->validated();
-        $queryDay = isset($validated['day']) ? $validated['day'] : ProgramController::DEFAULT_PROGRAM_DAY;
+        $queryDay = isset($validated['day']) ? $validated['day'] : $this->getCurrentProgramDay($edition);
 
         /** @var \App\Models\EventDay|null $eventDay */
         $eventDay = $edition->event_days()->orderBy('date', 'ASC')->skip($queryDay - 1)->first();
@@ -68,5 +70,15 @@ class ProgramController extends Controller
             'queryDay' => fn () => intval($queryDay),
             'totalDays' => fn () => intval($totalDays),
         ]);
+    }
+
+    private function getCurrentProgramDay(Edition $edition)
+    {
+        $today = Carbon::today();
+        $dates = $edition->event_days()->orderBy('date', 'ASC')->pluck('date');
+
+        $currentDayId = key($dates->filter(fn ($date) => $date == $today)->all());
+
+        return $currentDayId ? $currentDayId + 1 : ProgramController::DEFAULT_PROGRAM_DAY;
     }
 }

--- a/resources/js/Components/Navbar.vue
+++ b/resources/js/Components/Navbar.vue
@@ -27,12 +27,7 @@ const homeSections: Routes = {
 };
 
 const pageRoutes: Routes = {
-    program: {
-        label: "Programa",
-        _query: {
-            day: 1,
-        },
-    },
+    program: { label: "Programa" },
     shop: { label: "Loja" },
     team: { label: "Equipa" },
 };


### PR DESCRIPTION
Closes #227

Instead of just selecting the default program day when the day is not passed in the request, the program page now checks if any of the event days are scheduled for the current day, and selects it automatically. 

The implementation done in this PR of the enhancement might seem a bit weird (and it is), partly due to the fact that we do not guarantee that the event days are ordered in the database. Because of that, we can't simply use the database id to select which day is chosen in the program page, since both orders will be different.

I've left some screenshots below displaying the new behavior (notice how the ID in the admin page and the program day are different):

![image](https://github.com/semanadeinformatica/website-2023/assets/75742355/73cf4c23-58b4-440f-9a73-c9ef16e344a4)

![image](https://github.com/semanadeinformatica/website-2023/assets/75742355/63cc85cb-84e0-4184-a038-b4f0102c761e)
